### PR TITLE
Fix PHP notice when $screen is not available

### DIFF
--- a/admin/class-wdat-admin.php
+++ b/admin/class-wdat-admin.php
@@ -96,7 +96,7 @@ if ( !class_exists( 'WDAT_Admin' ) ) {
 			if ( '_product_attributes' == $meta_key && is_admin() && function_exists('get_current_screen') ) {
 
 				$screen = get_current_screen();
-				if ( 'add' === $screen->action ) {
+				if ( isset( $screen->action ) && 'add' === $screen->action ) {
 
 					$attrs = get_option( 'wdat_attributes' );
 					if ( !empty( $attrs ) ) {


### PR DESCRIPTION
Hi 👋🏼

We were getting some notices in the log during a AJAX call because `$screen` was null.
This is a safe & easy solution to that.

```
PHP Notice:  Trying to get property 'action' of non-object in /plugins/woo-default-attributes/admin/class-wdat-admin.php on line 99
PHP Stack trace:
PHP   3. do_action() /wp-admin/admin-ajax.php:100
PHP   4. WP_Hook->do_action() /wp-includes/plugin.php:453
PHP   5. WP_Hook->apply_filters() /wp-includes/class-wp-hook.php:310
PHP   6. ADSL_Request_Handler::get_fragments() /wp-includes/class-wp-hook.php:286
PHP   7. do_action() /plugins/agent-design-shopping-lists/includes/classes/helpers/class-request-handler.php:92
PHP   8. WP_Hook->do_action() /wp-includes/plugin.php:453
PHP   9. WP_Hook->apply_filters() /wp-includes/class-wp-hook.php:310
PHP  10. ADSL_Query->prepare_for_fragments() /wp-includes/class-wp-hook.php:286
PHP  11. ADSL_Product->__construct() /plugins/agent-design-shopping-lists/includes/classes/query.php:379
PHP  12. ADSL_Product->setup() /plugins/agent-design-shopping-lists/includes/classes/helpers/class-product.php:106
PHP  13. wc_get_product() /plugins/agent-design-shopping-lists/includes/classes/helpers/class-product.php:116
PHP  14. WC_Product_Factory->get_product() /plugins/woocommerce/includes/wc-product-functions.php:64
PHP  15. WC_Product_Variation->__construct() /plugins/woocommerce/includes/class-wc-product-factory.php:46
PHP  16. WC_Product_Variation->__construct() /plugins/woocommerce/includes/class-wc-product-variation.php:53
PHP  17. WC_Product_Variation->__construct() /plugins/woocommerce/includes/class-wc-product-simple.php:24
PHP  18. WC_Data_Store->read() /plugins/woocommerce/includes/abstracts/abstract-wc-product.php:134
PHP  19. WC_Product_Variation_Data_Store_CPT->read() /plugins/woocommerce/includes/class-wc-data-store.php:159
PHP  20. wc_get_product_variation_attributes() /plugins/woocommerce/includes/data-stores/class-wc-product-variation-data-store-cpt.php:75
PHP  21. get_post_meta() /plugins/woocommerce/includes/wc-product-functions.php:625
PHP  22. get_metadata() /wp-includes/post.php:1837
PHP  23. apply_filters() /wp-includes/meta.php:489
PHP  24. WP_Hook->apply_filters() /wp-includes/plugin.php:203
PHP  25. WDAT_Admin->get_post_metadata() /wp-includes/class-wp-hook.php:288
```